### PR TITLE
Added two points in population selector and multiplied by 1.0 instead of...

### DIFF
--- a/mozaik/sheets/population_selector.py
+++ b/mozaik/sheets/population_selector.py
@@ -160,7 +160,7 @@ class SimilarAnnotationSelector(PopulationSelector):
           picked = []
           z = self.sheet.pop.all_cells.astype(int)
           vals = [self.sheet.get_neuron_annotation(i,self.parameters.annotation) for i in xrange(0,len(z))]
-          if self.parameters.period != 0
+          if self.parameters.period != 0:
             pikced = [i for i in xrange(0,len(z)) if abs(vals[i]-self.parameters.value) < self.parameters.distance]
           else:
             pikced = [i for i in xrange(0,len(z)) if circular_dist(vals[i],self.parameters.value,self.parameters.period) < self.parameters.distance]  

--- a/mozaik/stimuli/vision/topographica_based.py
+++ b/mozaik/stimuli/vision/topographica_based.py
@@ -43,9 +43,9 @@ class SparseNoise(TopographicaBasedVisualStimulus):
         assert (self.time_per_image/self.frame_duration) % 1.0 == 0.0
                 
     def frames(self):
-            
+  
         aux = imagen.random.SparseNoise(
-                                      grid_density = self.grid_size / self.size_x,
+                                      grid_density = self.grid_size * 1.0 / self.size_x,
                                       grid = self.grid,
                                       offset= 0,
                                       scale= 2 * self.background_luminance,
@@ -80,7 +80,7 @@ class DenseNoise(TopographicaBasedVisualStimulus):
   
     def frames(self):
         aux = imagen.random.DenseNoise(
-                                       grid_density = self.grid_size / self.size_x,
+                                       grid_density = self.grid_size * 1.0 / self.size_x,
                                        offset = 0,
                                        scale = 2 * self.background_luminance, 
                                        bounds = BoundingBox(radius=self.size_x/2),


### PR DESCRIPTION
... 1 in topographica_based

Avoid division by zero in case that grid_size is passed as an integer in Dense and Sparse Noise
