### PR TITLE
Add Travis-CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: pytest-check
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      entry: black --check .
+      language_version: python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: bionic
+
+language: python
+python:
+- "2.7"
+
+before_install:
+- sudo apt-get -y install python-dev python-pip python-nose subversion git libopenmpi-dev g++ libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev zlib1g-dev libpng++-dev libncurses5 libncurses5-dev libreadline-dev liblapack-dev libblas-dev gfortran libgsl0-dev openmpi-bin python-tk cmake
+- git clone https://github.com/antolikjan/imagen.git && cd imagen && python setup.py install && cd .. # Hacky solution until imagen gets added as submodule
+- python setup.py install
+
+install:
+- pip install -r requirements.txt
+
+script:
+- pytest --cov=mozaik
+
+after_success:
+- codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ python:
 
 before_install:
 - sudo apt-get -y install python-dev python-pip python-nose subversion git libopenmpi-dev g++ libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev zlib1g-dev libpng++-dev libncurses5 libncurses5-dev libreadline-dev liblapack-dev libblas-dev gfortran libgsl0-dev openmpi-bin python-tk cmake
+- sudo apt-get -y install python3-dev python3-pip python3-setuptools # black is only available in python 3
 - git clone https://github.com/antolikjan/imagen.git && cd imagen && python setup.py install && cd .. # Hacky solution until imagen gets added as submodule
 - python setup.py install
 
 install:
 - pip install -r requirements.txt
+- pip3 install black # black is only available in python 3
 
 script:
+- black --check .
 - pytest --cov=mozaik
 
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -214,5 +214,18 @@ To run tests::
 
   docker run --rm -v "`pwd`:/app" antolikjan/mozaik:dev pytest
 
+Testing, Autoformat, Continuous Integration
+-------------------------------
+
+In case you want to contribute to the project, you need to make sure your code passes all unit tests and is formatted with the Black autoformatter. You can make sure this is the case by running `pytest && black --check .` from the project directory. If you use the setup below, pre-commit will do the checks for you when you try to commit. Travis-CI will run the same steps for your pull request once you submit it to the project.
+
+To install pytest, black and pre-commit::
+
+  pip install pytest pytest-cov pytest-randomly coverage pre-commit
+  pre-commit install
+  sudo apt-get -y install python3-dev python3-pip python3-setuptools
+  pip3 install black
+
+
 :copyright: Copyright 2011-2013 by the *mozaik* team, see AUTHORS.
 :license: `CECILL <http://www.cecill.info/>`_, see LICENSE for details.

--- a/mozaik/stimuli/vision/topographica_based.py
+++ b/mozaik/stimuli/vision/topographica_based.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+# TODO: Remove this once we switch to Python 3
 """
 The file contains stimuli that use topographica to generate the stimulus
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.black]
+exclude = '''
+
+(
+# Remove progressively as unit tests get added
+# We do not want to refactor without checking functionality
+ setup.py
+ | mozaik/core.py
+ | mozaik/cli.py
+ | mozaik/space.py
+ | mozaik/controller.py
+ | mozaik/__init__.py
+ | mozaik/meta_workflow
+ | mozaik/connectors
+ | mozaik/tools
+ | mozaik/experiments
+ | mozaik/visualization
+ | mozaik/models
+ | mozaik/storage
+ | mozaik/analysis
+ | mozaik/sheets
+ | mozaik/stimuli
+ | examples/VogelsAbbott2005
+ | examples/TextureModel
+| build
+| doc
+| imagen
+| \.git
+)
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ psutil==5.7.0
 PyNN==0.9.5
 quantities==0.12.4
 scipy==1.2.3
+pytest==4.6.11
+pytest-cov==2.10.1
+pytest-randomly==1.2.3
+coverage==5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pytest==4.6.11
 pytest-cov==2.10.1
 pytest-randomly==1.2.3
 coverage==5.3
+pre-commit==1.21.0


### PR DESCRIPTION
Travis-CI needs to be set up by the project owner:

1. Sign up (can be done through GitHub): https://travis-ci.com/signin
2. Activate the repository through Travis-CI: https://travis-ci.com/getting_started

Currently there are no tests running Nest, so I haven't added it into the Travis installation.

Black autoformat is currently set to ignore most files in the project; I propose to incrementally remove files from the exclusion list, once there are sufficient pytests for them.

Also added pre-commit (runs all tests and autoformat check when locally commiting) and a relevant section for setting it up in the README.