### PR TITLE
Correction to allow PyNNDistribution in cells parameters 

### DIFF
--- a/mozaik/sheets/__init__.py
+++ b/mozaik/sheets/__init__.py
@@ -106,7 +106,8 @@ class Sheet(BaseComponent):
         for k in self.parameters.cell.params.keys():
             if isinstance(self.parameters.cell.params[k],PyNNDistribution):
                self.dist_params[k]=self.parameters.cell.params[k]
-               del self.parameters.cell.params[k]
+        for dist_k in self.dist_params.keys():
+            del self.parameters.cell.params[dist_k]
         
 
     def setup_to_record_list(self):


### PR DESCRIPTION
Defining a cell parameter as PyNNDistribution was producing the following error: RuntimeError: dictionary keys changed during iteration. This correction deletes the keys corresponding to the cell parameters defined as PyNNDistribution after the iteration rather than during it.