### PR TITLE
Adding Nest 3.1 python dependencies in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ ____________
  
 Now you can install all other dependencies in this protected environment::
 
-  pip3 install numpy scipy mpi4py matplotlib quantities lazyarray interval Pillow param==1.5.1 parameters neo==0.9.0 cython pynn psutil future requests elephant
+  pip3 install numpy scipy mpi4py matplotlib quantities lazyarray interval Pillow param==1.5.1 parameters neo==0.9.0 cython pynn psutil future requests elephant pytest-xdist pytest-timeout junitparser
 
 Next we will manually install several packages. It is probably the best if you create a separate directory in an appropriate
 place, where you will download and install the packages from.


### PR DESCRIPTION
When creating the previous pull request, I forgot to add the changes relative to the additional python libraries that are needed in Nest 3 to run the tests in the make installcheck.