### PR TITLE
Parametrized PyNN distribution

### DIFF
--- a/tests/parametrization/param_original_PyNNDistribution/defaults
+++ b/tests/parametrization/param_original_PyNNDistribution/defaults
@@ -1,0 +1,3 @@
+{
+    'num_samples' : PyNNDistribution(name='uniform',low=25,high=65)
+}

--- a/tests/parametrization/param_parametrized_PyNNDistribution/defaults
+++ b/tests/parametrization/param_parametrized_PyNNDistribution/defaults
@@ -1,0 +1,10 @@
+{
+    'num_samples' : {
+        'class_name': 'PyNNDistribution',
+        'params': {
+                'name': 'uniform',
+                'low': 25,
+                'high': 65,
+            },
+    },
+}

--- a/tests/parametrization/test_parametrization.py
+++ b/tests/parametrization/test_parametrization.py
@@ -7,10 +7,12 @@ import os
 from collections import OrderedDict
 import pytest
 
+
 class TestParametrization:
     """
     Tests for the TestParametrization class
     """
+
     def setup_class(cls):
         os.chdir("tests/parametrization/")
 
@@ -18,14 +20,17 @@ class TestParametrization:
         p["mozaik_seed"] = 1023
         p["pynn_seed"] = 936395
         mozaik.setup_mpi(**p)
-        cls.param_original_PyNNDistribution = load_parameters('param_original_PyNNDistribution/defaults')
+        cls.param_original_PyNNDistribution = load_parameters(
+            "param_original_PyNNDistribution/defaults"
+        )
 
         mozaik.setup_mpi(**p)
-        cls.param_parametrized_PyNNDistribution = load_parameters('param_parametrized_PyNNDistribution/defaults')
+        cls.param_parametrized_PyNNDistribution = load_parameters(
+            "param_parametrized_PyNNDistribution/defaults"
+        )
 
     def test_parametrization_PyNNDistribution(self):
         assert (
-            self.param_original_PyNNDistribution.num_samples.next() == self.param_parametrized_PyNNDistribution.num_samples.next()
+            self.param_original_PyNNDistribution.num_samples.next()
+            == self.param_parametrized_PyNNDistribution.num_samples.next()
         ), "num_samples of the two parametrization generate different numbers"
-
-

--- a/tests/parametrization/test_parametrization.py
+++ b/tests/parametrization/test_parametrization.py
@@ -1,0 +1,31 @@
+import matplotlib
+
+matplotlib.use("Agg")
+import mozaik
+from mozaik.tools.distribution_parametrization import load_parameters
+import os
+from collections import OrderedDict
+import pytest
+
+class TestParametrization:
+    """
+    Tests for the TestParametrization class
+    """
+    def setup_class(cls):
+        os.chdir("tests/parametrization/")
+
+        p = OrderedDict()
+        p["mozaik_seed"] = 1023
+        p["pynn_seed"] = 936395
+        mozaik.setup_mpi(**p)
+        cls.param_original_PyNNDistribution = load_parameters('param_original_PyNNDistribution/defaults')
+
+        mozaik.setup_mpi(**p)
+        cls.param_parametrized_PyNNDistribution = load_parameters('param_parametrized_PyNNDistribution/defaults')
+
+    def test_parametrization_PyNNDistribution(self):
+        assert (
+            self.param_original_PyNNDistribution.num_samples.next() == self.param_parametrized_PyNNDistribution.num_samples.next()
+        ), "num_samples of the two parametrization generate different numbers"
+
+

--- a/tests/parametrization/test_parametrization.py
+++ b/tests/parametrization/test_parametrization.py
@@ -29,7 +29,7 @@ class TestParametrization:
             "param_parametrized_PyNNDistribution/defaults"
         )
 
-        os.chdir("../../../")
+        os.chdir("../../")
 
     def test_parametrization_PyNNDistribution(self):
         assert (

--- a/tests/parametrization/test_parametrization.py
+++ b/tests/parametrization/test_parametrization.py
@@ -29,6 +29,8 @@ class TestParametrization:
             "param_parametrized_PyNNDistribution/defaults"
         )
 
+        os.chdir("../../../")
+
     def test_parametrization_PyNNDistribution(self):
         assert (
             self.param_original_PyNNDistribution.num_samples.next()


### PR DESCRIPTION
Adding the possibility to parametrize PyNNDistributions (and any other arbitrary class initialiser used in the parameters) when doing a parameter search