### PR TITLE
Add experiment override support for Mozaik workflows

### DIFF
--- a/.github/workflows/mozaik-setup.yml
+++ b/.github/workflows/mozaik-setup.yml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get install python3-setuptools subversion git libopenmpi-dev g++ libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev zlib1g-dev libpng++-dev libncurses6 libncurses-dev libreadline-dev liblapack-dev libblas-dev gfortran libgsl0-dev openmpi-bin python3-tk cmake
         pip3 install pytest pytest-cov pytest-randomly coverage black
         # TODO: Add pynn once we switch from our custom to the official release
-        pip3 install numpy scipy mpi4py matplotlib quantities lazyarray interval Pillow param==1.5.1 parameters neo==0.12.0 cython==3.0.10 psutil future requests elephant pytest-xdist pytest-timeout junitparser numba numpyencoder sphinx imageio pandas scikit-image
+        pip3 install "numpy<2" scipy mpi4py matplotlib quantities lazyarray interval Pillow param==1.5.1 parameters neo==0.12.0 cython==3.0.10 psutil future requests elephant pytest-xdist pytest-timeout junitparser numba numpyencoder sphinx imageio pandas scikit-image
 
     - name: Download and install imagen
       run: |

--- a/mozaik/controller.py
+++ b/mozaik/controller.py
@@ -1,9 +1,13 @@
 r"""
 This is the nexus of workflow execution controll of *mozaik*.
 """
+
 from mozaik.cli import parse_workflow_args
 from mozaik.storage.datastore import Hdf5DataStore, PickledDataStore
-from mozaik.tools.distribution_parametrization import MozaikExtendedParameterSet, load_parameters
+from mozaik.tools.distribution_parametrization import (
+    MozaikExtendedParameterSet,
+    load_parameters,
+)
 from mozaik.tools.misc import result_directory_name
 from mozaik.stimuli import EndOfSimulationBlank
 from collections import OrderedDict
@@ -13,30 +17,39 @@ import mozaik
 import time
 from datetime import datetime
 import logging
-from mozaik.tools.json_export import save_json, get_experimental_protocols, get_recorders, get_stimuli
+from mozaik.tools.json_export import (
+    save_json,
+    get_experimental_protocols,
+    get_recorders,
+    get_stimuli,
+)
 from parameters import ParameterSet
+import copy
 
 
 logger = mozaik.getMozaikLogger()
 
+
 class Global:
     r"""global variable container currently only containing the root_directory variable that points to the root directory of the model specification"""
-    root_directory = './'
+
+    root_directory = "./"
+
 
 class FancyFormatter(logging.Formatter):
     r"""
     A log formatter that colours and indents the log message depending on the level.
     """
-    
+
     DEFAULT_INDENTS = {
-        'CRITICAL': "",
-        'ERROR': "",
-        'WARNING': "",
-        'HEADER': "",
-        'INFO': "  ",
-        'DEBUG': "    ",
+        "CRITICAL": "",
+        "ERROR": "",
+        "WARNING": "",
+        "HEADER": "",
+        "INFO": "  ",
+        "DEBUG": "    ",
     }
-    
+
     def __init__(self, fmt=None, datefmt=None, mpi_rank=None):
         logging.Formatter.__init__(self, fmt, datefmt)
         self._indents = FancyFormatter.DEFAULT_INDENTS
@@ -44,7 +57,7 @@ class FancyFormatter(logging.Formatter):
             self.prefix = ""
         else:
             self.prefix = "%-3d" % mpi_rank
-    
+
     def format(self, record):
         s = logging.Formatter.format(self, record)
         if record.levelname == "HEADER":
@@ -52,21 +65,25 @@ class FancyFormatter(logging.Formatter):
         return self.prefix + self._indents[record.levelname] + s
 
 
-def init_logging(filename, file_level=logging.INFO, console_level=logging.WARNING, mpi_rank=None):
+def init_logging(
+    filename, file_level=logging.INFO, console_level=logging.WARNING, mpi_rank=None
+):
     if mpi_rank is None:
         mpi_fmt = ""
     else:
         mpi_fmt = "%3d " % mpi_rank
-    logging.basicConfig(level=file_level,
-                        format='%%(asctime)s %s%%(name)-10s %%(levelname)-6s %%(message)s [%%(pathname)s:%%(lineno)d]' % mpi_fmt,
-                        filename=filename,
-                        filemode='w')
+    logging.basicConfig(
+        level=file_level,
+        format="%%(asctime)s %s%%(name)-10s %%(levelname)-6s %%(message)s [%%(pathname)s:%%(lineno)d]"
+        % mpi_fmt,
+        filename=filename,
+        filemode="w",
+    )
     console = logging.StreamHandler()
     console.setLevel(console_level)
-    console.setFormatter(FancyFormatter('%(message)s', mpi_rank=mpi_rank))
-    logging.getLogger('').addHandler(console)
+    console.setFormatter(FancyFormatter("%(message)s", mpi_rank=mpi_rank))
+    logging.getLogger("").addHandler(console)
     return console
-
 
 
 def setup_logging():
@@ -74,11 +91,197 @@ def setup_logging():
     This functions sets up logging.
     """
     if mozaik.mpi_comm:
-        init_logging(Global.root_directory + "log", file_level=logging.INFO,
-                     console_level=logging.INFO, mpi_rank=mozaik.mpi_comm.rank)  
+        init_logging(
+            Global.root_directory + "log",
+            file_level=logging.INFO,
+            console_level=logging.INFO,
+            mpi_rank=mozaik.mpi_comm.rank,
+        )
     else:
-        init_logging(Global.root_directory + "log", file_level=logging.INFO,
-                 console_level=logging.INFO)  
+        init_logging(
+            Global.root_directory + "log",
+            file_level=logging.INFO,
+            console_level=logging.INFO,
+        )
+
+
+def split_modified_parameters(modified_parameters):
+    r"""
+    Split modified parameters into model parameters and experiment parameters.
+
+    Parameters
+    ----------
+
+    modified_parameters : dict
+        Dictionary of parameter overrides parsed from the command line.
+
+    Returns
+    -------
+
+    model_modified_parameters : dict
+        Dictionary containing only overrides that should be applied to the
+        model parameter tree.
+
+    experiment_modified_parameters : dict
+        Dictionary containing only overrides that should be applied to named
+        experiment definitions.
+
+    Notes
+    -----
+
+    Experiment parameters are expected in the form
+    ``experiments.<experiment_name>.<parameter_path>`` and are handled
+    separately from the model parameter tree.
+    """
+    experiment_modified_parameters = {}
+    model_modified_parameters = {}
+
+    for key, value in modified_parameters.items():
+        if key.startswith("experiments."):
+            experiment_modified_parameters[key] = value
+        else:
+            model_modified_parameters[key] = value
+
+    return model_modified_parameters, experiment_modified_parameters
+
+
+def group_experiment_overrides(experiment_modified_parameters):
+    r"""
+    Group experiment overrides by experiment name.
+
+    Parameters
+    ----------
+
+    experiment_modified_parameters : dict
+        Dictionary containing experiment overrides in the form
+        ``experiments.<experiment_name>.<parameter_path>``.
+
+    Returns
+    -------
+
+    grouped_overrides : OrderedDict
+        Ordered dictionary mapping experiment names to dictionaries of
+        parameter paths and override values.
+
+    Raises
+    ------
+
+    ValueError
+        If an override does not contain both an experiment name and a
+        parameter path.
+    """
+    grouped_overrides = OrderedDict()
+    for key, value in experiment_modified_parameters.items():
+        parts = key.split(".")
+        if len(parts) < 3:
+            raise ValueError(
+                "Experiment override '%s' must have the form "
+                "'experiments.<experiment_name>.<parameter_path>'" % key
+            )
+
+        experiment_name = parts[1]
+        parameter_path = ".".join(parts[2:])
+        if not parameter_path:
+            raise ValueError("Experiment override '%s' is missing parameter path" % key)
+
+        if experiment_name not in grouped_overrides:
+            grouped_overrides[experiment_name] = OrderedDict()
+        grouped_overrides[experiment_name][parameter_path] = value
+
+    return grouped_overrides
+
+
+def instantiate_named_experiments(
+    model, experiment_specs, experiment_modified_parameters
+):
+    r"""
+    Instantiate named experiment specifications after applying overrides.
+
+    Parameters
+    ----------
+
+    model : Model
+        The model on which to execute the experiments.
+
+    experiment_specs : OrderedDict
+        Ordered dictionary mapping experiment names to tuples
+        ``(experiment_class, parameter_set)`` where ``experiment_class`` is the
+        class to instantiate and ``parameter_set`` contains the default
+        parameters for that experiment.
+
+    experiment_modified_parameters : dict
+        Dictionary containing experiment overrides in the form
+        ``experiments.<experiment_name>.<parameter_path>``.
+
+    Returns
+    -------
+
+    experiment_list : list
+        List of instantiated experiment objects in execution order.
+
+    experiment_parameter_list : list
+        List describing the final parameterization of each experiment in a form
+        suitable for storing in the datastore.
+
+    Raises
+    ------
+
+    ValueError
+        If an override references a missing experiment name or cannot be
+        applied to the corresponding parameter set.
+
+    TypeError
+        If the experiment specification does not follow the expected
+        ``(experiment_class, parameter_set)`` tuple format.
+    """
+    grouped_overrides = group_experiment_overrides(experiment_modified_parameters)
+    unknown_experiments = [
+        experiment_name
+        for experiment_name in grouped_overrides.keys()
+        if experiment_name not in experiment_specs
+    ]
+    if unknown_experiments:
+        raise ValueError(
+            "Unknown experiment override target(s): %s"
+            % ", ".join(sorted(unknown_experiments))
+        )
+
+    experiment_list = []
+    experiment_parameter_list = []
+
+    for experiment_name, spec in experiment_specs.items():
+        if not isinstance(spec, tuple) or len(spec) != 2:
+            raise TypeError(
+                "OrderedDict-based experiments must contain "
+                "(experiment_class, parameter_set) tuples. Invalid spec for '%s'."
+                % experiment_name
+            )
+
+        experiment_class, default_parameters = spec
+        if not isinstance(default_parameters, ParameterSet):
+            raise TypeError(
+                "Experiment spec '%s' must define a ParameterSet as second tuple item."
+                % experiment_name
+            )
+
+        parameters = copy.deepcopy(default_parameters)
+        overrides = grouped_overrides.get(experiment_name, OrderedDict())
+        if overrides:
+            try:
+                parameters.replace_values(**overrides)
+            except Exception as exc:
+                raise ValueError(
+                    "Failed to apply overrides for experiment '%s': %s"
+                    % (experiment_name, exc)
+                ) from exc
+
+        experiment = experiment_class(model, parameters)
+        experiment_list.append(experiment)
+        experiment_parameter_list.append(
+            (str(experiment.__class__), str(experiment.parameters))
+        )
+
+    return experiment_list, experiment_parameter_list
 
 
 def prepare_workflow(simulation_name, model_class):
@@ -86,6 +289,7 @@ def prepare_workflow(simulation_name, model_class):
     Executes the following preparatory steps for simulation workflow:
 
     - Load simulation parameters
+    - Split model and experiment parameter overrides
     - Initialize random seeds
     - Create directory for results
     - Store loaded parameters
@@ -103,7 +307,12 @@ def prepare_workflow(simulation_name, model_class):
 
     parameters : dict
         Loaded parameters to initialize the simulation and model with
-                 
+
+    experiment_modified_parameters : dict
+        Dictionary of experiment overrides separated from the model parameter
+        tree. These are applied only if the experiment factory returns named
+        experiment specifications.
+
     """
     (
         simulation_run_name,
@@ -113,12 +322,17 @@ def prepare_workflow(simulation_name, model_class):
         modified_parameters,
     ) = parse_workflow_args()
 
+    model_modified_parameters, experiment_modified_parameters = (
+        split_modified_parameters(modified_parameters)
+    )
 
     # First we load the parameters just to retrieve seeds. We will throw them away, because at this stage the PyNNDistribution values were not yet initialized correctly.
-    parameters = load_parameters(parameters_url,modified_parameters)
-    p=OrderedDict()
-    if 'mozaik_seed' in parameters : p['mozaik_seed'] = parameters['mozaik_seed']
-    if 'pynn_seed' in parameters : p['pynn_seed'] = parameters['pynn_seed']
+    parameters = load_parameters(parameters_url, model_modified_parameters)
+    p = OrderedDict()
+    if "mozaik_seed" in parameters:
+        p["mozaik_seed"] = parameters["mozaik_seed"]
+    if "pynn_seed" in parameters:
+        p["pynn_seed"] = parameters["pynn_seed"]
 
     # Now initialize mpi with the seeds
     print("START MPI")
@@ -126,62 +340,69 @@ def prepare_workflow(simulation_name, model_class):
 
     # Now really load parameters
     print("Loading parameters")
-    parameters = load_parameters(parameters_url,modified_parameters)
+    parameters = load_parameters(parameters_url, model_modified_parameters)
     print("Finished loading parameters")
 
     import pyNN.nest as sim
 
     # Create results directory
-    timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
 
-    ddir  = result_directory_name(simulation_run_name,simulation_name,modified_parameters)
+    ddir = result_directory_name(
+        simulation_run_name, simulation_name, modified_parameters
+    )
 
     if mozaik.mpi_comm and mozaik.mpi_comm.rank != mozaik.MPI_ROOT:
-        Global.root_directory = parameters.results_dir + ddir + '/' + str(mozaik.mpi_comm.rank) + '/'
+        Global.root_directory = (
+            parameters.results_dir + ddir + "/" + str(mozaik.mpi_comm.rank) + "/"
+        )
         mozaik.mpi_comm.barrier()
     else:
-        Global.root_directory = parameters.results_dir + ddir + '/'
-
+        Global.root_directory = parameters.results_dir + ddir + "/"
 
     os.makedirs(Global.root_directory)
     if mozaik.mpi_comm and mozaik.mpi_comm.rank == mozaik.MPI_ROOT:
         mozaik.mpi_comm.barrier()
 
-
     if mozaik.mpi_comm.rank == mozaik.MPI_ROOT:
         # Store simulation run info, if we are the 0 rank process,
         # with several components to be stored/filled in later during the simulation run
         sim_info = {
-            'submission_date' : None,
-            'run_date': datetime.now().strftime('%d/%m/%Y-%H:%M:%S'),
-            'simulation_run_name': simulation_run_name,
-            'model_name': simulation_name,
+            "submission_date": None,
+            "run_date": datetime.now().strftime("%d/%m/%Y-%H:%M:%S"),
+            "simulation_run_name": simulation_run_name,
+            "model_name": simulation_name,
             "model_description": model_class.__doc__,
-            'results': {"$ref": "results.json"},
-            'stimuli': {"$ref": "stimuli.json"},
-            'recorders': {"$ref": "recorders.json"},
-            'experimental_protocols': {"$ref": "experimental_protocols.json"},
-            'parameters': {"$ref": "parameters.json"},
+            "results": {"$ref": "results.json"},
+            "stimuli": {"$ref": "stimuli.json"},
+            "recorders": {"$ref": "recorders.json"},
+            "experimental_protocols": {"$ref": "experimental_protocols.json"},
+            "parameters": {"$ref": "parameters.json"},
         }
-        save_json(sim_info, Global.root_directory + 'sim_info.json')
-        save_json(parameters.to_dict(), Global.root_directory + 'parameters.json')
-        save_json(modified_parameters, Global.root_directory + 'modified_parameters.json')
+        save_json(sim_info, Global.root_directory + "sim_info.json")
+        save_json(parameters.to_dict(), Global.root_directory + "parameters.json")
+        save_json(
+            modified_parameters, Global.root_directory + "modified_parameters.json"
+        )
         recorders = get_recorders(parameters.to_dict())
-        save_json(recorders, Global.root_directory + 'recorders.json')
+        save_json(recorders, Global.root_directory + "recorders.json")
 
     setup_logging()
 
-    return sim, num_threads, parameters
+    return sim, num_threads, parameters, experiment_modified_parameters
+
 
 def run_workflow(simulation_name, model_class, create_experiments):
     r"""
     This is the main function that executes a workflow.
     It expects it gets the simulation, class of the model, and a function that will create_experiments.
-    The create experiments function get a instance of a model as the only parameter and it is expected to return
-    a list of Experiment instances that should be executed over the model.
+    The create_experiments function gets an instance of a model as its only parameter and it is expected to return
+    either a list of Experiment instances that should be executed over the model, or an OrderedDict mapping experiment
+    names to tuples ``(experiment_class, parameter_set)``.
     The run workflow will automatically parse the command line to determine the simulator to be used and the path to the root parameter file.
     It will also accept . (point) delimited path to parameteres in the configuration tree, and corresponding values. It will replace each such provided
     parameter's value with the provided one on the command line.
+
     Parameters
     ----------
 
@@ -192,122 +413,204 @@ def run_workflow(simulation_name, model_class, create_experiments):
         The class from which the model instance will be created from.
 
     create_experiments : func
-        The function that returns the list of experiments that will be executed on the model.
+        The function that returns either the list of experiments that will be
+        executed on the model or an OrderedDict of named experiment
+        specifications.
 
     Examples
     --------
 
     The intended syntax of the commandline is as follows (note that the simulation run name is the last argument):
     >>> python userscript simulator_name num_threads parameter_file_path modified_parameter_path_1 modified_parameter_value_1 ... modified_parameter_path_n modified_parameter_value_n simulation_run_name
-    
+
+    Experiment overrides use the dedicated syntax
+    ``experiments.<experiment_name>.<parameter_path>`` and are only accepted
+    when ``create_experiments`` returns an OrderedDict of named experiment
+    specifications.
+
     """
 
     # Prepare workflow - read parameters, setup logging, etc.
-    sim, num_threads, parameters = prepare_workflow(simulation_name, model_class)
+    sim, num_threads, parameters, experiment_modified_parameters = prepare_workflow(
+        simulation_name, model_class
+    )
     # Prepare model to run experiments on
-    model = model_class(sim,num_threads,parameters)
+    model = model_class(sim, num_threads, parameters)
+    experiment_definition = create_experiments(model)
+
+    if isinstance(experiment_definition, list):
+        if experiment_modified_parameters:
+            raise ValueError(
+                "Experiment overrides were provided, but create_experiments(model) "
+                "returned a list. Use an OrderedDict of named experiment specs for "
+                "experiment overrides."
+            )
+        experiment_list = experiment_definition
+        experiment_parameter_list = None
+    elif isinstance(experiment_definition, OrderedDict):
+        experiment_list, experiment_parameter_list = instantiate_named_experiments(
+            model,
+            experiment_definition,
+            experiment_modified_parameters,
+        )
+    else:
+        raise TypeError(
+            "create_experiments(model) must return either a list of experiments "
+            "or an OrderedDict of named (experiment_class, parameter_set) specs."
+        )
+
     # Run experiments with previously read parameters on the prepared model
-    data_store = run_experiments(model,create_experiments(model),parameters)
+    data_store = run_experiments(
+        model,
+        experiment_list,
+        parameters,
+        experiment_parameter_list=experiment_parameter_list,
+    )
 
     if mozaik.mpi_comm.rank == mozaik.MPI_ROOT:
         data_store.save()
     import resource
-    print("Final memory usage: %iMB" % (resource.getrusage(resource.RUSAGE_SELF).ru_maxrss/(1024)))
+
+    print(
+        "Final memory usage: %iMB"
+        % (resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (1024))
+    )
     return (data_store, model)
 
-def run_experiments(model,experiment_list,parameters,load_from=None):
+
+def run_experiments(
+    model, experiment_list, parameters, load_from=None, experiment_parameter_list=None
+):
     r"""
-    This is function called by :func:.run_workflow that executes the experiments in the `experiment_list` over the model. 
+    This is function called by :func:.run_workflow that executes the experiments in the `experiment_list` over the model.
     Alternatively, if load_from is specified it will load an existing simulation from the path specified in load_from.
-    
+
     Parameters
     ----------
-    
+
     model : Model
         The model to execute experiments on.
-    
+
     experiment_list : list
         The list of experiments to execute.
-    
+
     parameters : ParameterSet
         The parameters given to the simulation run.
-          
+
     load_from : str
         If not None it will load the simulation from the specified directory.
-              
+
+    experiment_parameter_list : list, optional
+        Optional explicit experiment parametrization metadata to store in the
+        datastore. If not supplied it will be derived from the instantiated
+        experiments in ``experiment_list``.
+
     Returns
     -------
-    
+
     data_store : DataStore
         The data store containing the recordings.
-               
+
     """
-    
+
     # first lets run all the measurements required by the experiments
-    logger.info('Starting Experiemnts')
+    logger.info("Starting Experiemnts")
     if load_from == None:
-        data_store = PickledDataStore(load=False,
-                                      parameters=MozaikExtendedParameterSet({'root_directory': Global.root_directory,'store_stimuli' : parameters.store_stimuli}))
-    else: 
-        data_store = PickledDataStore(load=True,
-                                      parameters=MozaikExtendedParameterSet({'root_directory': load_from,'store_stimuli' : parameters.store_stimuli}))
-    
+        data_store = PickledDataStore(
+            load=False,
+            parameters=MozaikExtendedParameterSet(
+                {
+                    "root_directory": Global.root_directory,
+                    "store_stimuli": parameters.store_stimuli,
+                }
+            ),
+        )
+    else:
+        data_store = PickledDataStore(
+            load=True,
+            parameters=MozaikExtendedParameterSet(
+                {"root_directory": load_from, "store_stimuli": parameters.store_stimuli}
+            ),
+        )
+
     data_store.set_neuron_ids(model.neuron_ids())
     data_store.set_neuron_positions(model.neuron_positions())
     data_store.set_neuron_annotations(model.neuron_annotations())
     data_store.set_model_parameters(parameters.pretty(expand_urls=True))
-    data_store.set_sheet_parameters(MozaikExtendedParameterSet(model.sheet_parameters()).pretty(expand_urls=True))
-    data_store.set_experiment_parametrization_list([(str(exp.__class__),str(exp.parameters)) for exp in experiment_list])
-    
+    data_store.set_sheet_parameters(
+        MozaikExtendedParameterSet(model.sheet_parameters()).pretty(expand_urls=True)
+    )
+    if experiment_parameter_list is None:
+        experiment_parameter_list = [
+            (str(exp.__class__), str(exp.parameters)) for exp in experiment_list
+        ]
+    data_store.set_experiment_parametrization_list(experiment_parameter_list)
+
     t0 = time.time()
-    simulation_run_time=0
-    model_exploded=False
-    for i,experiment in enumerate(experiment_list):
-        logger.info('Starting experiment: ' + experiment.__class__.__name__)
+    simulation_run_time = 0
+    model_exploded = False
+    for i, experiment in enumerate(experiment_list):
+        logger.info("Starting experiment: " + experiment.__class__.__name__)
         stimuli = experiment.return_stimuli()
         unpresented_stimuli_indexes = data_store.identify_unpresented_stimuli(stimuli)
-        logger.info('Running model')
-        experiment_run_time, model_exploded = experiment.run(data_store,unpresented_stimuli_indexes)
+        logger.info("Running model")
+        experiment_run_time, model_exploded = experiment.run(
+            data_store, unpresented_stimuli_indexes
+        )
         simulation_run_time += experiment_run_time
         if model_exploded:
-            logger.info('ERROR: Model exploded, stopping simulation!')
+            logger.info("ERROR: Model exploded, stopping simulation!")
             break
-        logger.info('Experiment %d/%d finished' % (i+1,len(experiment_list)))
+        logger.info("Experiment %d/%d finished" % (i + 1, len(experiment_list)))
 
     last_blank_run_time = 0
     # Do a reset after the last stimulus. If reset is done as blank stimulus, this makes sure we have some blank recorded also after last stimulus.
-    ds =  OrderedDict()
+    ds = OrderedDict()
 
     if parameters.null_stimulus_period != 0:
-        s = EndOfSimulationBlank(trial=0,duration=parameters.null_stimulus_period,frame_duration=parameters.null_stimulus_period)
-        (segments,null_segments,input_stimulus,last_blank_run_time,_) = model.present_stimulus_and_record(s,ds)
-        data_store.add_recording(segments,s)
-        data_store.add_stimulus(input_stimulus,s)
-        data_store.add_direct_stimulation(ds,s)
+        s = EndOfSimulationBlank(
+            trial=0,
+            duration=parameters.null_stimulus_period,
+            frame_duration=parameters.null_stimulus_period,
+        )
+        (segments, null_segments, input_stimulus, last_blank_run_time, _) = (
+            model.present_stimulus_and_record(s, ds)
+        )
+        data_store.add_recording(segments, s)
+        data_store.add_stimulus(input_stimulus, s)
+        data_store.add_direct_stimulation(ds, s)
         if null_segments != []:
-                data_store.add_null_recording(null_segments,s) 
+            data_store.add_null_recording(null_segments, s)
     else:
         last_blank_run_time = 0
-        
+
     total_run_time = time.time() - t0
     mozaik_run_time = total_run_time - simulation_run_time - last_blank_run_time
 
     # Adding the state (represented by a randomly generated number) of the rng of every MPI process to the datastore
     if mozaik.mpi_comm:
         rngs_state = mozaik.mpi_comm.gather(float(mozaik.rng.rand(1)), root=0)
-        log = {'rngs_state': rngs_state, 'explosion_detected': model_exploded}
+        log = {"rngs_state": rngs_state, "explosion_detected": model_exploded}
     else:
-        log = {'explosion_detected': model_exploded}
+        log = {"explosion_detected": model_exploded}
     data_store.set_simulation_log(log)
 
     if not model_exploded and mozaik.mpi_comm.rank == mozaik.MPI_ROOT:
-        logger.info('Total simulation run time: %.0fs' % total_run_time)
-        logger.info('Simulator run time: %.0fs (%d%%)' % (simulation_run_time, int(simulation_run_time /total_run_time * 100)))
-        logger.info('Mozaik run time: %.0fs (%d%%)' % (mozaik_run_time, int(mozaik_run_time /total_run_time * 100)))
-    
+        logger.info("Total simulation run time: %.0fs" % total_run_time)
+        logger.info(
+            "Simulator run time: %.0fs (%d%%)"
+            % (simulation_run_time, int(simulation_run_time / total_run_time * 100))
+        )
+        logger.info(
+            "Mozaik run time: %.0fs (%d%%)"
+            % (mozaik_run_time, int(mozaik_run_time / total_run_time * 100))
+        )
+
     experimental_protocols = get_experimental_protocols(data_store)
-    stimuli = get_stimuli(data_store,parameters.store_stimuli, parameters.input_space)
-    save_json(experimental_protocols, Global.root_directory + 'experimental_protocols.json')
-    save_json(stimuli, Global.root_directory + 'stimuli.json')
+    stimuli = get_stimuli(data_store, parameters.store_stimuli, parameters.input_space)
+    save_json(
+        experimental_protocols, Global.root_directory + "experimental_protocols.json"
+    )
+    save_json(stimuli, Global.root_directory + "stimuli.json")
 
     return data_store

--- a/mozaik/controller.py
+++ b/mozaik/controller.py
@@ -26,7 +26,6 @@ from mozaik.tools.json_export import (
 from parameters import ParameterSet
 import copy
 
-
 logger = mozaik.getMozaikLogger()
 
 
@@ -573,7 +572,7 @@ def run_experiments(
             duration=parameters.null_stimulus_period,
             frame_duration=parameters.null_stimulus_period,
         )
-        (segments, null_segments, input_stimulus, last_blank_run_time, _) = (
+        segments, null_segments, input_stimulus, last_blank_run_time, _ = (
             model.present_stimulus_and_record(s, ds)
         )
         data_store.add_recording(segments, s)

--- a/mozaik/meta_workflow/parameter_search.py
+++ b/mozaik/meta_workflow/parameter_search.py
@@ -5,130 +5,184 @@ from datetime import datetime
 import os
 import time
 import re
+import shlex
 from mozaik.cli import parse_parameter_search_args
 from mozaik.tools.misc import result_directory_name
 import json
 from mozaik.tools.json_export import save_json
 
+
 class ParameterSearchBackend(object):
     r"""
     This is the parameter search backend interface. The :func:.`execute_job`
-    implements the execution of the job, using the information given to the 
+    implements the execution of the job, using the information given to the
     constructor, and the dictionary of modified parameters given in its arguments.
     """
-    def execute_job(self,run_script,simulator_name,parameters_url,parameters,simulation_run_name):
-         """
-         This function recevies the list of parameters to modify and their values, and has to 
-         execute the corresponding mozaik simulation.
-         
-         Parameters
-         ----------
 
-         parameters : dict
-             The dictionary holding the names of parameters to be modified as keys, and the values to set them to as the corresponding values. 
-         
-         """
-         raise NotImplemented
+    def execute_job(
+        self,
+        run_script,
+        simulator_name,
+        parameters_url,
+        parameters,
+        simulation_run_name,
+    ):
+        """
+        This function recevies the list of parameters to modify and their values, and has to
+        execute the corresponding mozaik simulation.
 
+        Parameters
+        ----------
+
+        parameters : dict
+            The dictionary holding the names of parameters to be modified as keys, and the values to set them to as the corresponding values.
+
+        """
+        raise NotImplemented
 
 
 class LocalSequentialBackend(object):
     r"""
-    This is the simplest backend that simply executes the simulation on the present 
+    This is the simplest backend that simply executes the simulation on the present
     machine sequentially (i.e. it waits for the simulation to end before starting new one).
     """
-     
-    def execute_job(self,run_script,simulator_name,parameters_url,parameters,simulation_run_name):
-         r"""
-         This function recevies the list of parameters to modify and their values, and has to 
-         execute the corresponding mozaik simulation.
-         
-         Parameters
-         ----------
 
-         parameters : dict
-             The dictionary holding the names of parameters to be modified as keys, and the values to set them to as the corresponding values. 
-         
-         """
-         modified_parameters = []
-         for k in parameters.keys():
-             modified_parameters.append(k)
-             modified_parameters.append(str(parameters[k]))
-         
-         subprocess.call(' '.join(["python", run_script, simulator_name, '1', parameters_url]+modified_parameters+['ParameterSearch']),shell=True)
+    def execute_job(
+        self,
+        run_script,
+        simulator_name,
+        parameters_url,
+        parameters,
+        simulation_run_name,
+    ):
+        r"""
+        This function recevies the list of parameters to modify and their values, and has to
+        execute the corresponding mozaik simulation.
 
+        Parameters
+        ----------
+
+        parameters : dict
+            The dictionary holding the names of parameters to be modified as keys, and the values to set them to as the corresponding values.
+
+        """
+        modified_parameters = []
+        for k in parameters.keys():
+            modified_parameters.append(k)
+            modified_parameters.append(repr(parameters[k]))
+
+        command = (
+            ["python", run_script, simulator_name, "1", parameters_url]
+            + modified_parameters
+            + ["ParameterSearch"]
+        )
+        subprocess.call(
+            " ".join(shlex.quote(str(token)) for token in command), shell=True
+        )
 
 
 class SlurmSequentialBackend(object):
     r"""
-    This is a back end that runs each simulation run as a slurm job. 
-    
+    This is a back end that runs each simulation run as a slurm job.
+
     Parameters
     ----------
 
     num_threads : int
         Number of threads per mpi process.
-    
+
     num_mpi : int
         Number of mpi processes to spawn per job.
-                  
+
     path_to_mozaik_env : string
-        Path to virtual environment in which mozaik is installed.                  
-                  
-    slurm_options : list(string), optional 
-        List of strings that will be passed to slurm sbatch command as options.  
+        Path to virtual environment in which mozaik is installed.
+
+    slurm_options : list(string), optional
+        List of strings that will be passed to slurm sbatch command as options.
 
     Notes
     -----
     The most common usage of slurm_options is to let slurm know how many mpi processed to spawn per job, and how to allocates resources to them.
-    
+
     """
-    def __init__(self,num_threads,num_mpi, path_to_mozaik_env, slurm_options=None):
+
+    def __init__(self, num_threads, num_mpi, path_to_mozaik_env, slurm_options=None):
         self.num_threads = num_threads
         self.num_mpi = num_mpi
         self.path_to_mozaik_env = path_to_mozaik_env
-        if slurm_options==None:
-           self.slurm_options=[]
+        if slurm_options == None:
+            self.slurm_options = []
         else:
-           self.slurm_options=slurm_options 
-        
-        
-        
-        
-    def execute_job(self,run_script,simulator_name,parameters_url,parameters,simulation_run_name):
-         r"""
-         This function recevies the list of parameters to modify and their values, and has to 
-         execute the corresponding mozaik simulation.
-         
-         Parameters
-         ----------
+            self.slurm_options = slurm_options
 
-         parameters : dict
-             The dictionary holding the names of parameters to be modified as keys, and the values to set them to as the corresponding values. 
-         
-         """
-         modified_parameters = []
-         for k in parameters.keys():
-             modified_parameters.append(k)
-             modified_parameters.append(str(parameters[k]))
-        
-     
-         from subprocess import Popen, PIPE, STDOUT
-         # use sbatch to queue job with params as in  slurm options (except job-geometry)
-         p = Popen(['sbatch'] + self.slurm_options +  ['-o',parameters['results_dir'][2:-2]+"/slurm-%j.out"],stdin=PIPE,stdout=PIPE,stderr=PIPE,text=True)
-         
-         # pass jobfile: sets slurm job geometry, sources env and starts simulation job from cwd 
-         data = '\n'.join([
-                            '#!/bin/bash',
-                            '#SBATCH -n ' + str(self.num_mpi),
-                            '#SBATCH -c ' + str(self.num_threads),
-                            'source ' + str(self.path_to_mozaik_env),
-                            'cd ' + os.getcwd(),
-                            ' '.join(["srun","--mpi=pmix_v5","python",run_script, simulator_name, str(self.num_threads) ,parameters_url]+modified_parameters+[simulation_run_name]+['>']  + [parameters['results_dir'][1:-1] +'/OUTFILE'+str(time.time())]),
-                        ]) 
-         print(p.communicate(input=data)[0])
-         print(data)
-         p.stdin.close()
+    def execute_job(
+        self,
+        run_script,
+        simulator_name,
+        parameters_url,
+        parameters,
+        simulation_run_name,
+    ):
+        r"""
+        This function recevies the list of parameters to modify and their values, and has to
+        execute the corresponding mozaik simulation.
+
+        Parameters
+        ----------
+
+        parameters : dict
+            The dictionary holding the names of parameters to be modified as keys, and the values to set them to as the corresponding values.
+
+        """
+        modified_parameters = []
+        for k in parameters.keys():
+            modified_parameters.append(k)
+            modified_parameters.append(repr(parameters[k]))
+
+        from subprocess import Popen, PIPE, STDOUT
+
+        # use sbatch to queue job with params as in  slurm options (except job-geometry)
+        p = Popen(
+            ["sbatch"]
+            + self.slurm_options
+            + ["-o", parameters["results_dir"] + "/slurm-%j.out"],
+            stdin=PIPE,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+
+        # pass jobfile: sets slurm job geometry, sources env and starts simulation job from cwd
+        command = (
+            [
+                "srun",
+                "--mpi=pmix_v5",
+                "python",
+                run_script,
+                simulator_name,
+                str(self.num_threads),
+                parameters_url,
+            ]
+            + modified_parameters
+            + [simulation_run_name]
+        )
+        data = "\n".join(
+            [
+                "#!/bin/bash",
+                "#SBATCH -n " + str(self.num_mpi),
+                "#SBATCH -c " + str(self.num_threads),
+                "source " + str(self.path_to_mozaik_env),
+                "cd " + os.getcwd(),
+                " ".join(shlex.quote(str(token)) for token in command)
+                + " > "
+                + shlex.quote(
+                    parameters["results_dir"] + "/OUTFILE" + str(time.time())
+                ),
+            ]
+        )
+        print(p.communicate(input=data)[0])
+        print(data)
+        p.stdin.close()
 
 
 class ParameterSearch(object):
@@ -136,74 +190,86 @@ class ParameterSearch(object):
     This class defines the interface of parameter search.
     Each ParameterSearch has to implement the function `generate_parameter_combinations`
     and `master_directory_name`.
-    
+
     The parameter search is executed with the function run_parameter_search.
-    
+
     Furthermore each ParameterSearch receives a backend object, that determines how the simulation
     with a given parameter combination is executed. This allows for user to define executaion
     mechanisms using various cluster scheaduling architectures. See :class:.`ParameterSearchBackend`
     for more details.
-     
+
     Parameters
     ----------
 
     params : ParameterSearchBackend
-        The job execution backend to use. 
-           
-           
+        The job execution backend to use.
+
+
     Examples
     --------
 
     The commandline usage should be:
-    
+
     >>> parameter_search_script simulation_run_script simulator_name path_to_root_parameter_file
 
     """
-    
-    def __init__(self,backend):
+
+    def __init__(self, backend):
         self.backend = backend
-    
+
     def generate_parameter_combinations(self):
         r"""
         Returns a list of dictionaries, each holding the modified parameters as keys, and a combination of their values as the values.
         """
         raise NotImplemented
-    
+
     def master_directory_name(self):
         r"""
         Returns the name of the master directory which will contain results from the invididual simulation runs.
         """
         raise NotImplemented
-        
+
     def run_parameter_search(self):
         r"""
         This method will run the parameter search replacing each combination of values defined by dictionary params
         in the default parametrization and runing the simulation with each such modified parameters,
         storing the results of each simulation run in a subdirectory named based on the given modified parameter names and their
         values.
-        
+
         It will read the command line for the name of the script that runs individual simulations, the simulator name and the root parameter file path
         Command line syntax:
-        
+
         python parameter_search_script simulation_run_script simulator_name root_parameter_file_name
         """
-        
+
         # Read parameters
         run_script, simulator_name, parameters_url = parse_parameter_search_args()
-        
-        timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
-        mdn = timestamp + "[" + parameters_url.replace('/','.') + "]" +  self.master_directory_name()
+
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        mdn = (
+            timestamp
+            + "["
+            + parameters_url.replace("/", ".")
+            + "]"
+            + self.master_directory_name()
+        )
         os.mkdir(mdn)
-        
-        counter=0
+
+        counter = 0
         combinations = self.generate_parameter_combinations()
-        save_json(combinations, mdn + '/parameter_combinations.json')
-        
+        save_json(combinations, mdn + "/parameter_combinations.json")
+
         for combination in combinations:
-            combination['results_dir']='\"\'' + os.getcwd() + '/' + mdn + '/\'\"'
-            self.backend.execute_job(run_script,simulator_name,parameters_url,combination,'ParameterSearch')
+            combination["results_dir"] = os.getcwd() + "/" + mdn + "/"
+            self.backend.execute_job(
+                run_script,
+                simulator_name,
+                parameters_url,
+                combination,
+                "ParameterSearch",
+            )
             counter = counter + 1
-            
+
         print("Submitted %d jobs." % counter)
 
 
@@ -211,96 +277,79 @@ class CombinationParameterSearch(ParameterSearch):
     r"""
     A ParameterSearch that recevies a list of parameters and list of values for each parameter to test.
     It will then test each of the combination of values.
-    
+
     Parameters
     ----------
 
     parameter_values : dict
         Dictionary containing parameter names as keys, and lists as values, each corresponding to the list of values to test for the given parameter.
-    
+
     """
-    def __init__(self,backend,parameter_values):
-        ParameterSearch.__init__(self,backend)
+
+    def __init__(self, backend, parameter_values):
+        ParameterSearch.__init__(self, backend)
         self.parameter_values = parameter_values
-    
+
     def generate_parameter_combinations(self):
         combs = []
         for combination in parameter_combinations(list(self.parameter_values.values())):
-            combs.append({a : b for (a,b) in zip (self.parameter_values.keys(),combination)})
-        return combs    
-        
+            combs.append(
+                {a: b for (a, b) in zip(self.parameter_values.keys(), combination)}
+            )
+        return combs
+
     def master_directory_name(self):
-        s = "CombinationParamSearch{" + ','.join([str(k) + ':' + (str(self.parameter_values[k]) if len(self.parameter_values[k]) < 5 else str(len(self.parameter_values[k]))) for k in self.parameter_values.keys()]) + '}/'
-        
+        s = (
+            "CombinationParamSearch{"
+            + ",".join(
+                [
+                    str(k)
+                    + ":"
+                    + (
+                        str(self.parameter_values[k])
+                        if len(self.parameter_values[k]) < 5
+                        else str(len(self.parameter_values[k]))
+                    )
+                    for k in self.parameter_values.keys()
+                ]
+            )
+            + "}/"
+        )
+
         if len(s) > 200:
-           s =  "CombinationParamSearch{" + str(len(self.parameter_values.keys())) + '}/'
+            s = (
+                "CombinationParamSearch{"
+                + str(len(self.parameter_values.keys()))
+                + "}/"
+            )
         return s
-            
+
+
 def parameter_combinations(arrays):
-    return _parameter_combinations_rec([],arrays)
-    
-def _parameter_combinations_rec(combination,arrays):
- if arrays == []:
-    return [combination]
- else:
-    return sum([_parameter_combinations_rec(combination[:] + [value],arrays[1:]) for value in arrays[0]],[])
-    
+    return _parameter_combinations_rec([], arrays)
 
-def parameter_search_run_script_distributed_slurm(simulation_name,master_results_dir,run_script,core_number):
+
+def _parameter_combinations_rec(combination, arrays):
+    if arrays == []:
+        return [combination]
+    else:
+        return sum(
+            [
+                _parameter_combinations_rec(combination[:] + [value], arrays[1:])
+                for value in arrays[0]
+            ],
+            [],
+        )
+
+
+def parameter_search_run_script_distributed_slurm(
+    simulation_name, master_results_dir, run_script, core_number
+):
     r"""
     Scheadules the execution of *run_script*, one per each parameter combination of an existing parameter search run.
     Each execution receives as the first commandline argument the directory in which the results for the given
     parameter combination were stored.
-    
-    Parameters
-    ----------
 
-    simulation_name : str
-        The name of the simulation.
-    
-    master_results_dir : str
-        The directory where the parameter search results are stored.
-    
-    run_script : str
-        The name of the script to be run. The directory name of the given parameter combination datastore will be passed to it as the first command line argument.
-    
-    core_number : int
-        How many cores to reserve per process.
-    
-    """
-    with open(master_results_dir + '/parameter_combinations.json', 'r', encoding='utf-8') as f:
-        combinations = json.load(f)
-
-    # first check whether all parameter combinations contain the same parameter names
-    assert len(set([tuple(set(comb.keys())) for comb in combinations])) == 1 , "The parameter search didn't occur over a fixed set of parameters"
-    
-    from subprocess import Popen, PIPE, STDOUT
-    for i,combination in enumerate(combinations):
-        rdn = master_results_dir+'/'+result_directory_name('ParameterSearch',simulation_name,combination)    
-        p = Popen(['sbatch'] +  ['-o',master_results_dir+"/slurm_analysis-%j.out" ],stdin=PIPE,stdout=PIPE,stderr=PIPE,text=True)
-         
-        # THIS IS A BIT OF A HACK, have to add customization for other people ...            
-        data = '\n'.join([
-                            '#!/bin/bash',
-                            '#SBATCH -J MozaikParamSearchAnalysis',
-                            '#SBATCH -c ' + str(core_number),
-                            'source /opt/software/mpi/openmpi-1.6.3-gcc/env',
-                            'source /home/antolikjan/env/mozaiknew/bin/activate',
-                            'cd ' + os.getcwd(),
-                            'echo "DSADSA"',                            
-                            ' '.join(["mpirun"," --mca mtl ^psm python",run_script,"'"+rdn+"'"]  +['>']  + ["'"+rdn +'/OUTFILE_analysis'+str(time.time()) + "'"]),
-                        ]) 
-        print(p.communicate(input=data)[0])
-        print(data)
-        p.stdin.close()
-
-
-def parameter_search_run_script_distributed_slurm_IoV(simulation_name,master_results_dir,run_script,core_number):
-    r"""
-    Scheadules the execution of *run_script*, one per each parameter combination of an existing parameter search run.
-    Each execution receives as the first commandline argument the directory in which the results for the given
-    parameter combination were stored.
-    
     Parameters
     ----------
 
@@ -312,42 +361,67 @@ def parameter_search_run_script_distributed_slurm_IoV(simulation_name,master_res
 
     run_script : str
         The name of the script to be run. The directory name of the given parameter combination datastore will be passed to it as the first command line argument.
-    
+
     core_number : int
         How many cores to reserve per process.
-    
+
     """
-    with open(master_results_dir + '/parameter_combinations.json', 'r', encoding='utf-8') as f:
+    with open(
+        master_results_dir + "/parameter_combinations.json", "r", encoding="utf-8"
+    ) as f:
         combinations = json.load(f)
 
     # first check whether all parameter combinations contain the same parameter names
-    assert len(set([tuple(set(comb.keys())) for comb in combinations])) == 1 , "The parameter search didn't occur over a fixed set of parameters"
-    
+    assert (
+        len(set([tuple(set(comb.keys())) for comb in combinations])) == 1
+    ), "The parameter search didn't occur over a fixed set of parameters"
+
     from subprocess import Popen, PIPE, STDOUT
-    for i,combination in enumerate(combinations):
-        rdn = master_results_dir+'/'+result_directory_name('ParameterSearch',simulation_name,combination)    
-        p = Popen(['sbatch'] +  ['-o',master_results_dir+"/slurm_analysis-%j.out" ],stdin=PIPE,stdout=PIPE,stderr=PIPE,text=True)
-         
-        # THIS IS A BIT OF A HACK, have to add customization for other people ...            
-        data = '\n'.join([
-                            '#!/bin/bash',
-                            '#SBATCH -J MozaikParamSearchAnalysis',
-                            '#SBATCH -c ' + str(core_number),
-                            'source /home/jantolik/virt_env/mozaiknew/bin/activate',
-                            'cd ' + os.getcwd(),
-                            'echo "DSADSA"',                            
-                            ' '.join(["python",run_script,"'"+rdn+"'"]  +['>']  + ["'"+rdn +'/OUTFILE_analysis'+str(time.time()) + "'"]),
-                        ]) 
+
+    for i, combination in enumerate(combinations):
+        rdn = (
+            master_results_dir
+            + "/"
+            + result_directory_name("ParameterSearch", simulation_name, combination)
+        )
+        p = Popen(
+            ["sbatch"] + ["-o", master_results_dir + "/slurm_analysis-%j.out"],
+            stdin=PIPE,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+
+        # THIS IS A BIT OF A HACK, have to add customization for other people ...
+        data = "\n".join(
+            [
+                "#!/bin/bash",
+                "#SBATCH -J MozaikParamSearchAnalysis",
+                "#SBATCH -c " + str(core_number),
+                "source /opt/software/mpi/openmpi-1.6.3-gcc/env",
+                "source /home/antolikjan/env/mozaiknew/bin/activate",
+                "cd " + os.getcwd(),
+                'echo "DSADSA"',
+                " ".join(
+                    ["mpirun", " --mca mtl ^psm python", run_script, "'" + rdn + "'"]
+                    + [">"]
+                    + ["'" + rdn + "/OUTFILE_analysis" + str(time.time()) + "'"]
+                ),
+            ]
+        )
         print(p.communicate(input=data)[0])
         print(data)
         p.stdin.close()
 
-def parameter_search_run_script_distributed_slurm_UK(simulation_name,master_results_dir,run_script,core_number):
+
+def parameter_search_run_script_distributed_slurm_IoV(
+    simulation_name, master_results_dir, run_script, core_number
+):
     r"""
     Scheadules the execution of *run_script*, one per each parameter combination of an existing parameter search run.
     Each execution receives as the first commandline argument the directory in which the results for the given
     parameter combination were stored.
-    
+
     Parameters
     ----------
 
@@ -358,35 +432,127 @@ def parameter_search_run_script_distributed_slurm_UK(simulation_name,master_resu
         The directory where the parameter search results are stored.
 
     run_script : str
-        The name of the script to be run. 
-        The directory name of the given parameter combination datastore will be passed to it 
+        The name of the script to be run. The directory name of the given parameter combination datastore will be passed to it as the first command line argument.
+
+    core_number : int
+        How many cores to reserve per process.
+
+    """
+    with open(
+        master_results_dir + "/parameter_combinations.json", "r", encoding="utf-8"
+    ) as f:
+        combinations = json.load(f)
+
+    # first check whether all parameter combinations contain the same parameter names
+    assert (
+        len(set([tuple(set(comb.keys())) for comb in combinations])) == 1
+    ), "The parameter search didn't occur over a fixed set of parameters"
+
+    from subprocess import Popen, PIPE, STDOUT
+
+    for i, combination in enumerate(combinations):
+        rdn = (
+            master_results_dir
+            + "/"
+            + result_directory_name("ParameterSearch", simulation_name, combination)
+        )
+        p = Popen(
+            ["sbatch"] + ["-o", master_results_dir + "/slurm_analysis-%j.out"],
+            stdin=PIPE,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+
+        # THIS IS A BIT OF A HACK, have to add customization for other people ...
+        data = "\n".join(
+            [
+                "#!/bin/bash",
+                "#SBATCH -J MozaikParamSearchAnalysis",
+                "#SBATCH -c " + str(core_number),
+                "source /home/jantolik/virt_env/mozaiknew/bin/activate",
+                "cd " + os.getcwd(),
+                'echo "DSADSA"',
+                " ".join(
+                    ["python", run_script, "'" + rdn + "'"]
+                    + [">"]
+                    + ["'" + rdn + "/OUTFILE_analysis" + str(time.time()) + "'"]
+                ),
+            ]
+        )
+        print(p.communicate(input=data)[0])
+        print(data)
+        p.stdin.close()
+
+
+def parameter_search_run_script_distributed_slurm_UK(
+    simulation_name, master_results_dir, run_script, core_number
+):
+    r"""
+    Scheadules the execution of *run_script*, one per each parameter combination of an existing parameter search run.
+    Each execution receives as the first commandline argument the directory in which the results for the given
+    parameter combination were stored.
+
+    Parameters
+    ----------
+
+    simulation_name : str
+        The name of the simulation.
+
+    master_results_dir : str
+        The directory where the parameter search results are stored.
+
+    run_script : str
+        The name of the script to be run.
+        The directory name of the given parameter combination datastore will be passed to it
         as the first command line argument.
 
     core_number : int
         How many cores to reserve per process.
-    
+
     """
-    with open(master_results_dir + '/parameter_combinations.json', 'r', encoding='utf-8') as f:
+    with open(
+        master_results_dir + "/parameter_combinations.json", "r", encoding="utf-8"
+    ) as f:
         combinations = json.load(f)
-    
+
     # first check whether all parameter combinations contain the same parameter names
-    assert len(set([tuple(set(comb.keys())) for comb in combinations])) == 1 , "The parameter search didn't occur over a fixed set of parameters"
-    
+    assert (
+        len(set([tuple(set(comb.keys())) for comb in combinations])) == 1
+    ), "The parameter search didn't occur over a fixed set of parameters"
+
     from subprocess import Popen, PIPE, STDOUT
-    for i,combination in enumerate(combinations):
-        rdn = master_results_dir+'/'+result_directory_name('ParameterSearch',simulation_name,combination)    
-        p = Popen(['sbatch'] +  ['-o',master_results_dir+"/slurm_analysis-%j.out" ],stdin=PIPE,stdout=PIPE,stderr=PIPE,text=True)
-         
-        # THIS IS A BIT OF A HACK, have to add customization for other people ...            
-        data = '\n'.join([
-                            '#!/bin/bash',
-                            '#SBATCH -J MozaikParamSearchAnalysis',
-                            '#SBATCH -c ' + str(core_number),
-                            '#SBATCH --hint=nomultithread',
-                            'source /home/antolikjan/virt_env/mozaiknew/bin/activate',
-                            'cd ' + os.getcwd(),
-                            ' '.join(["python",run_script,"'"+rdn+"'"]  +['>']  + ["'"+rdn +'/OUTFILE_analysis'+str(time.time()) + "'"]),
-                        ]) 
+
+    for i, combination in enumerate(combinations):
+        rdn = (
+            master_results_dir
+            + "/"
+            + result_directory_name("ParameterSearch", simulation_name, combination)
+        )
+        p = Popen(
+            ["sbatch"] + ["-o", master_results_dir + "/slurm_analysis-%j.out"],
+            stdin=PIPE,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+
+        # THIS IS A BIT OF A HACK, have to add customization for other people ...
+        data = "\n".join(
+            [
+                "#!/bin/bash",
+                "#SBATCH -J MozaikParamSearchAnalysis",
+                "#SBATCH -c " + str(core_number),
+                "#SBATCH --hint=nomultithread",
+                "source /home/antolikjan/virt_env/mozaiknew/bin/activate",
+                "cd " + os.getcwd(),
+                " ".join(
+                    ["python", run_script, "'" + rdn + "'"]
+                    + [">"]
+                    + ["'" + rdn + "/OUTFILE_analysis" + str(time.time()) + "'"]
+                ),
+            ]
+        )
         print(p.communicate(input=data)[0])
         print(data)
         p.stdin.close()

--- a/mozaik/tools/misc.py
+++ b/mozaik/tools/misc.py
@@ -2,22 +2,26 @@ r"""
 Various helper functions.
 """
 
-import numpy                                                                             
-import numpy.random                                                                             
+import hashlib
+import re
+
+import numpy
+import numpy.random
 from numpy import pi, sqrt, exp, power
+
 
 def sample_from_bin_distribution(bins, number_of_samples, seed):
     r"""
     Samples from a distribution defined by a vector the sum in. The vector doesn't have to add up to one
-    it will be automatically normalized. 
-    
-    
+    it will be automatically normalized.
+
+
     Parameters
     ----------
-    
+
     bins : ndarray
         The returned samples correspond to the bins in `bins` - the numpy array defining the bin distribution
-      
+
     number_of_samples : int
         Number of samples to generate.
 
@@ -34,47 +38,109 @@ def sample_from_bin_distribution(bins, number_of_samples, seed):
 
     return si
 
-_normal_function_sqertofpi = sqrt(2*pi)
+
+_normal_function_sqertofpi = sqrt(2 * pi)
+
+
 def normal_function(x, mean=0, sigma=1.0):
     r"""
     Returns the value of probability density of normal distribution N(mean,sigma) at point `x`.
     """
-    return numpy.exp(-numpy.power((x - mean)/sigma, 2)/2) / (sigma * _normal_function_sqertofpi)
+    return numpy.exp(-numpy.power((x - mean) / sigma, 2) / 2) / (
+        sigma * _normal_function_sqertofpi
+    )
 
-def find_neuron(which,positions):
+
+def find_neuron(which, positions):
     r"""
     Finds a neuron depending on which:
-    'center' - the most central neuron in the sheet 
+    'center' - the most central neuron in the sheet
     'top_right' - the top_right neuron in the sheet
     'top_left' - the top_left neuron in the sheet
     'bottom_left' - the bottom_left neuron in the sheet
     'bottom_right' - the bottom_right neuron in the sheet
-        
+
     """
-    minx = numpy.min(positions[0,:])
-    maxx = numpy.max(positions[0,:])
-    miny = numpy.min(positions[1,:])
-    maxy = numpy.max(positions[1,:])
-    
-    def closest(x,y,positions):
-        return numpy.argmin(numpy.sqrt(numpy.power(positions[0,:].flatten()-x,2) + numpy.power(positions[1,:].flatten()-y,2)))
-    
-    if which == 'center':
-       cl =  closest(minx+(maxx-minx)/2,miny+(maxy-miny)/2,positions)
-    elif which == 'top_right':
-       cl = closest(maxx,maxy,positions)
-    elif which == 'top_left':
-       cl = closest(minx,maxy,positions)
-    elif which == 'bottom_left':
-       cl = closest(minx,miny,positions)
-    elif which == 'bottom_right':
-       cl = closest(maxx,miny,positions)
-       
+    minx = numpy.min(positions[0, :])
+    maxx = numpy.max(positions[0, :])
+    miny = numpy.min(positions[1, :])
+    maxy = numpy.max(positions[1, :])
+
+    def closest(x, y, positions):
+        return numpy.argmin(
+            numpy.sqrt(
+                numpy.power(positions[0, :].flatten() - x, 2)
+                + numpy.power(positions[1, :].flatten() - y, 2)
+            )
+        )
+
+    if which == "center":
+        cl = closest(minx + (maxx - minx) / 2, miny + (maxy - miny) / 2, positions)
+    elif which == "top_right":
+        cl = closest(maxx, maxy, positions)
+    elif which == "top_left":
+        cl = closest(minx, maxy, positions)
+    elif which == "bottom_left":
+        cl = closest(minx, miny, positions)
+    elif which == "bottom_right":
+        cl = closest(maxx, miny, positions)
+
     return cl
 
-def result_directory_name(simulation_run_name,simulation_name,modified_parameters):
-    modified_params_str = '_'.join([str(k) + ":" + str(modified_parameters[k]) for k in sorted(modified_parameters.keys()) if k!='results_dir'])
+
+def _sanitize_result_directory_component(value):
+    r"""
+    Convert a parameter key or value into a filesystem-safe label.
+
+    This preserves the original value for metadata files, but removes path
+    separators and other characters that would otherwise fragment result
+    directories into nested paths.
+    """
+    sanitized = re.sub(r"[\\/]+", "_", str(value))
+    sanitized = re.sub(r"\s+", "_", sanitized)
+    sanitized = re.sub(r"[^A-Za-z0-9._=-]+", "_", sanitized)
+    return sanitized.strip("_")
+
+
+def _shorten_result_directory_component(value, max_length=48):
+    r"""
+    Keep filesystem labels compact enough for nested result paths.
+
+    Long values retain a readable prefix and append a short hash so different
+    parameter values still map to distinct directory names.
+    """
+    sanitized = _sanitize_result_directory_component(value)
+    if len(sanitized) <= max_length:
+        return sanitized
+
+    digest = hashlib.sha1(sanitized.encode("utf-8")).hexdigest()[:10]
+    prefix_length = max_length - len(digest) - 1
+    return sanitized[:prefix_length].rstrip("_") + "_" + digest
+
+
+def result_directory_name(simulation_run_name, simulation_name, modified_parameters):
+    modified_params_str = "_".join(
+        [
+            _shorten_result_directory_component(k, max_length=24)
+            + ":"
+            + _shorten_result_directory_component(modified_parameters[k])
+            for k in sorted(modified_parameters.keys())
+            if k != "results_dir"
+        ]
+    )
     if len(modified_params_str) > 100:
-        modified_params_str = '_'.join([str(k).split('.')[-1] + ":" + str(modified_parameters[k]) for k in sorted(modified_parameters.keys()) if k!='results_dir'])
-    
-    return simulation_name + '_' + simulation_run_name + '_____' + modified_params_str
+        modified_params_str = "_".join(
+            [
+                _shorten_result_directory_component(
+                    str(k).split(".")[-1], max_length=20
+                )
+                + ":"
+                + _shorten_result_directory_component(
+                    modified_parameters[k], max_length=20
+                )
+                for k in sorted(modified_parameters.keys())
+                if k != "results_dir"
+            ]
+        )
+
+    return simulation_name + "_" + simulation_run_name + "_____" + modified_params_str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,23 @@ exclude = '''
  | mozaik/core.py
  | mozaik/cli.py
  | mozaik/space.py
- | mozaik/controller.py
  | mozaik/__init__.py
- | mozaik/meta_workflow
+ | mozaik/meta_workflow/__init__.py
+ | mozaik/meta_workflow/analysis.py
+ | mozaik/meta_workflow/visualization.py
  | mozaik/connectors
- | mozaik/tools
+ | mozaik/tools/__init__.py
+ | mozaik/tools/circ_stat.py
+ | mozaik/tools/datastore_utils.py
+ | mozaik/tools/debug.py
+ | mozaik/tools/distribution_parametrization.py
+ | mozaik/tools/json_export.py
+ | mozaik/tools/mozaik_parametrized.py
+ | mozaik/tools/neo_object_operations.py
+ | mozaik/tools/pyNN.py
+ | mozaik/tools/stats.py
+ | mozaik/tools/stgen.py
+ | mozaik/tools/units.py
  | mozaik/experiments/__init__.py
  | mozaik/experiments/direct_stimulations_mixins.py
  | mozaik/experiments/vision.py

--- a/tests/test_controller_experiment_overrides.py
+++ b/tests/test_controller_experiment_overrides.py
@@ -1,0 +1,207 @@
+from collections import OrderedDict
+from types import SimpleNamespace
+
+import pytest
+from parameters import ParameterSet
+
+import mozaik.controller
+from mozaik.experiments import NoStimulation
+
+
+class DummyDataStore:
+    """
+    Minimal datastore stub used to verify that ``run_workflow`` reaches the
+    save step on the MPI root rank.
+    """
+
+    def __init__(self):
+        self.saved = False
+
+    def save(self):
+        self.saved = True
+
+
+class DummyModel:
+    """
+    Minimal model stub for controller tests.
+
+    The controller only needs to instantiate the model and pass it forward to
+    experiment construction, so no additional model behavior is required here.
+    """
+
+    def __init__(self, sim, num_threads, parameters):
+        self.sim = sim
+        self.num_threads = num_threads
+        self.parameters = parameters
+
+
+def _install_common_monkeypatches(monkeypatch, experiment_overrides):
+    """
+    Patch common controller dependencies so tests can focus on branch logic.
+
+    This helper bypasses the real workflow preparation path, which would
+    otherwise parse CLI arguments, load parameter files, initialize MPI-related
+    state, and create result directories. Instead it injects a minimal fixed
+    workflow context together with the experiment overrides under test.
+
+    Parameters
+    ----------
+
+    monkeypatch : pytest.MonkeyPatch
+        Pytest fixture used to replace controller dependencies for the duration
+        of the test.
+
+    experiment_overrides : OrderedDict
+        Experiment override dictionary returned by the patched
+        ``prepare_workflow`` helper.
+    """
+    parameters = ParameterSet({"store_stimuli": False, "null_stimulus_period": 0})
+    monkeypatch.setattr(
+        mozaik.controller,
+        "prepare_workflow",
+        lambda simulation_name, model_class: (
+            object(),
+            1,
+            parameters,
+            experiment_overrides,
+        ),
+    )
+    monkeypatch.setattr(
+        mozaik.controller.mozaik,
+        "mpi_comm",
+        SimpleNamespace(rank=0),
+    )
+    monkeypatch.setattr(mozaik.controller.mozaik, "MPI_ROOT", 0)
+
+
+def test_run_workflow_list_legacy_path(monkeypatch):
+    """
+    Verify that the legacy list-based experiment workflow remains unchanged.
+
+    When no experiment overrides are present and ``create_experiments`` returns
+    an already-instantiated list, the controller should pass that list straight
+    through to ``run_experiments`` without synthesizing explicit experiment
+    metadata.
+    """
+    _install_common_monkeypatches(monkeypatch, OrderedDict())
+    captured = {}
+
+    def fake_run_experiments(
+        model,
+        experiment_list,
+        parameters,
+        load_from=None,
+        experiment_parameter_list=None,
+    ):
+        captured["experiment_list"] = experiment_list
+        captured["experiment_parameter_list"] = experiment_parameter_list
+        return DummyDataStore()
+
+    monkeypatch.setattr(mozaik.controller, "run_experiments", fake_run_experiments)
+
+    def create_experiments(model):
+        return [NoStimulation(model, ParameterSet({"duration": 10.0}))]
+
+    data_store, model = mozaik.controller.run_workflow(
+        "dummy",
+        DummyModel,
+        create_experiments,
+    )
+
+    assert isinstance(model, DummyModel)
+    assert len(captured["experiment_list"]) == 1
+    assert captured["experiment_list"][0].parameters.duration == 10.0
+    assert captured["experiment_parameter_list"] is None
+    assert data_store.saved is True
+
+
+def test_run_workflow_ordereddict_applies_overrides(monkeypatch):
+    """
+    Verify that the OrderedDict-based workflow applies overrides before
+    experiment instantiation.
+
+    The resulting instantiated experiment should contain the overridden value,
+    and the controller should store legacy experiment metadata tuples for the
+    datastore.
+    """
+    _install_common_monkeypatches(
+        monkeypatch,
+        OrderedDict(
+            {
+                "experiments.blank.duration": 42.0,
+            }
+        ),
+    )
+    captured = {}
+
+    def fake_run_experiments(
+        model,
+        experiment_list,
+        parameters,
+        load_from=None,
+        experiment_parameter_list=None,
+    ):
+        captured["experiment_list"] = experiment_list
+        captured["experiment_parameter_list"] = experiment_parameter_list
+        return DummyDataStore()
+
+    monkeypatch.setattr(mozaik.controller, "run_experiments", fake_run_experiments)
+
+    def create_experiments(model):
+        return OrderedDict(
+            [
+                ("blank", (NoStimulation, ParameterSet({"duration": 10.0}))),
+            ]
+        )
+
+    data_store, model = mozaik.controller.run_workflow(
+        "dummy",
+        DummyModel,
+        create_experiments,
+    )
+
+    assert isinstance(model, DummyModel)
+    assert len(captured["experiment_list"]) == 1
+    assert captured["experiment_list"][0].parameters.duration == 42.0
+    assert captured["experiment_parameter_list"] == [
+        (str(NoStimulation), str(captured["experiment_list"][0].parameters))
+    ]
+    assert data_store.saved is True
+
+
+def test_run_workflow_list_rejects_experiment_overrides(monkeypatch):
+    """
+    Verify that new-style experiment overrides are rejected for legacy
+    list-based experiment factories.
+    """
+    _install_common_monkeypatches(
+        monkeypatch,
+        OrderedDict({"experiments.blank.duration": 42.0}),
+    )
+
+    def create_experiments(model):
+        return [NoStimulation(model, ParameterSet({"duration": 10.0}))]
+
+    with pytest.raises(ValueError, match="Experiment overrides were provided"):
+        mozaik.controller.run_workflow("dummy", DummyModel, create_experiments)
+
+
+def test_run_workflow_ordereddict_rejects_unknown_target(monkeypatch):
+    """
+    Verify that overrides fail fast when they reference a missing named
+    experiment.
+    """
+    _install_common_monkeypatches(
+        monkeypatch,
+        OrderedDict({"experiments.missing.duration": 42.0}),
+    )
+
+    def create_experiments(model):
+        return OrderedDict(
+            [
+                ("blank", (NoStimulation, ParameterSet({"duration": 10.0}))),
+            ]
+        )
+
+    with pytest.raises(ValueError, match="Unknown experiment override target"):
+        mozaik.controller.run_workflow("dummy", DummyModel, create_experiments)

--- a/tests/tools/test_misc.py
+++ b/tests/tools/test_misc.py
@@ -1,0 +1,55 @@
+import math
+
+import numpy as np
+
+from mozaik.tools.misc import (
+    find_neuron,
+    normal_function,
+    sample_from_bin_distribution,
+)
+
+
+def test_sample_from_bin_distribution_returns_reproducible_indices():
+    bins = np.array([1.0, 3.0, 6.0])
+
+    samples_a = sample_from_bin_distribution(bins, 12, seed=7)
+    samples_b = sample_from_bin_distribution(bins, 12, seed=7)
+
+    assert len(samples_a) == 12
+    assert np.array_equal(samples_a, samples_b)
+    assert np.all(samples_a >= 0)
+    assert np.all(samples_a < len(bins))
+
+
+def test_sample_from_bin_distribution_handles_empty_bins():
+    assert sample_from_bin_distribution(np.array([]), 5, seed=3) == []
+
+
+def test_normal_function_matches_standard_normal_peak():
+    value = normal_function(np.array([0.0]), mean=0.0, sigma=1.0)[0]
+
+    np.testing.assert_approx_equal(
+        value, 1.0 / math.sqrt(2.0 * math.pi), significant=12
+    )
+
+
+def test_normal_function_is_symmetric_around_mean():
+    x = np.array([-0.5, 0.5])
+    values = normal_function(x, mean=0.0, sigma=2.0)
+
+    np.testing.assert_allclose(values[0], values[1])
+
+
+def test_find_neuron_returns_expected_named_positions():
+    positions = np.array(
+        [
+            [-1.0, 1.0, -1.0, 1.0, 0.0],
+            [1.0, 1.0, -1.0, -1.0, 0.0],
+        ]
+    )
+
+    assert find_neuron("top_left", positions) == 0
+    assert find_neuron("top_right", positions) == 1
+    assert find_neuron("bottom_left", positions) == 2
+    assert find_neuron("bottom_right", positions) == 3
+    assert find_neuron("center", positions) == 4


### PR DESCRIPTION
## Summary

This PR adds support for overriding experiment parameters in Mozaik workflows while preserving backward compatibility with the legacy list-based `create_experiments(model)` path.

It introduces support for an `OrderedDict`-based experiment specification workflow, where experiments are named and experiment-specific overrides like `experiments.<name>.<parameter>` are applied before experiment instantiation.

## Main changes

- add support in `controller.py` for splitting model overrides from experiment overrides
- support `OrderedDict[name, (ExperimentClass, ParameterSet)]` experiment specifications
- apply `experiments.*` overrides before experiment instantiation
- keep legacy list-based workflows unchanged
- raise an explicit error if `experiments.*` overrides are used with the legacy list-based workflow
- update parameter search command construction to use `repr(...)` for parameter values and shell-safe quoting
- sanitize and shorten parameter-derived result directory names in `misc.py`
- remove the Black exclude entries for:
  - `mozaik/controller.py`
  - `mozaik/meta_workflow/parameter_search.py`
  - `mozaik/tools/misc.py`
- add tests for controller experiment override behavior
- add lightweight unit tests for legacy helper functions in `mozaik/tools/misc.py`

## Testing

Validated in Slurm in the non-LSV1M test suite.

One passing run summary:
- `930 passed`
- `21 skipped`
- `37 deselected`
- `0 failed`
- `0 errors`

Additional targeted tests added in this PR:
- `tests/test_controller_experiment_overrides.py`
- `tests/tools/test_misc.py`